### PR TITLE
Solve TypeError when running anndata2muon.ipynb to save mu data

### DIFF
--- a/Papalexi, E., Mimitou, E.P., Butler, A.W. et al. ECCITE/anndata2muon.ipynb
+++ b/Papalexi, E., Mimitou, E.P., Butler, A.W. et al. ECCITE/anndata2muon.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "58b77e0d",
    "metadata": {
     "scrolled": true
@@ -15,7 +15,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 117,
+   "execution_count": null,
    "id": "5656781c",
    "metadata": {
     "scrolled": false
@@ -31,15 +31,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 118,
+   "execution_count": null,
    "id": "22974bde",
    "metadata": {},
    "outputs": [],
    "source": [
     "for ann in [rna, adt, gdo, hto]:\n",
-    "    \n",
+    "    all_column_names = ann.obs_keys()\n",
+    "    all_column_types = ann.obs.dtypes.to_dict()\n",
     "    # remove duplicate columns \n",
     "    ann.obs = ann.obs.T.drop_duplicates().T\n",
+    "    all_column_names_new = ann.obs_keys()\n",
+    "    for duplicate_column_name in list(set(all_column_names) - set(all_column_names_new)):\n",
+    "        all_column_types.pop(duplicate_column_name)\n",
+    "    # revert columns' types\n",
+    "    ann.obs = ann.obs.astype(all_column_types)\n",
     "\n",
     "    # rename observations\n",
     "    ann.obs = ann.obs.rename(columns={'gene':'gene_target', 'crispr':'perturbation'})\n",
@@ -50,58 +56,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 119,
+   "execution_count": null,
    "id": "f732e89b",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/opt/miniconda3/envs/pertpy/lib/python3.8/site-packages/mudata/_core/mudata.py:376: UserWarning: Cannot join columns with the same name because var_names are intersecting.\n",
-      "  warnings.warn(\n"
-     ]
-    },
-    {
-     "data": {
-      "text/html": [
-       "<pre>MuData object with n_obs × n_vars = 20729 × 18776\n",
-       "  4 modalities\n",
-       "    rna:\t20729 x 18649\n",
-       "      obs:\t&#x27;orig.ident&#x27;, &#x27;nCount_RNA&#x27;, &#x27;nFeature_RNA&#x27;, &#x27;nCount_HTO&#x27;, &#x27;nFeature_HTO&#x27;, &#x27;nCount_GDO&#x27;, &#x27;nCount_ADT&#x27;, &#x27;nFeature_ADT&#x27;, &#x27;percent.mito&#x27;, &#x27;MULTI_ID&#x27;, &#x27;HTO_classification&#x27;, &#x27;guide_ID&#x27;, &#x27;gene_target&#x27;, &#x27;perturbation&#x27;, &#x27;replicate&#x27;, &#x27;S.Score&#x27;, &#x27;G2M.Score&#x27;, &#x27;Phase&#x27;\n",
-       "      var:\t&#x27;name&#x27;\n",
-       "    adt:\t20729 x 4\n",
-       "      obs:\t&#x27;orig.ident&#x27;, &#x27;nCount_RNA&#x27;, &#x27;nFeature_RNA&#x27;, &#x27;nCount_HTO&#x27;, &#x27;nFeature_HTO&#x27;, &#x27;nCount_GDO&#x27;, &#x27;nCount_ADT&#x27;, &#x27;nFeature_ADT&#x27;, &#x27;percent.mito&#x27;, &#x27;MULTI_ID&#x27;, &#x27;HTO_classification&#x27;, &#x27;guide_ID&#x27;, &#x27;gene_target&#x27;, &#x27;perturbation&#x27;, &#x27;replicate&#x27;, &#x27;S.Score&#x27;, &#x27;G2M.Score&#x27;, &#x27;Phase&#x27;\n",
-       "      var:\t&#x27;name&#x27;\n",
-       "    hto:\t20729 x 12\n",
-       "      obs:\t&#x27;orig.ident&#x27;, &#x27;nCount_RNA&#x27;, &#x27;nFeature_RNA&#x27;, &#x27;nCount_HTO&#x27;, &#x27;nFeature_HTO&#x27;, &#x27;nCount_GDO&#x27;, &#x27;nCount_ADT&#x27;, &#x27;nFeature_ADT&#x27;, &#x27;percent.mito&#x27;, &#x27;MULTI_ID&#x27;, &#x27;HTO_classification&#x27;, &#x27;guide_ID&#x27;, &#x27;gene_target&#x27;, &#x27;perturbation&#x27;, &#x27;replicate&#x27;, &#x27;S.Score&#x27;, &#x27;G2M.Score&#x27;, &#x27;Phase&#x27;\n",
-       "      var:\t&#x27;name&#x27;\n",
-       "    gdo:\t20729 x 111\n",
-       "      obs:\t&#x27;orig.ident&#x27;, &#x27;nCount_RNA&#x27;, &#x27;nFeature_RNA&#x27;, &#x27;nCount_HTO&#x27;, &#x27;nFeature_HTO&#x27;, &#x27;nCount_GDO&#x27;, &#x27;nCount_ADT&#x27;, &#x27;nFeature_ADT&#x27;, &#x27;percent.mito&#x27;, &#x27;MULTI_ID&#x27;, &#x27;HTO_classification&#x27;, &#x27;guide_ID&#x27;, &#x27;gene_target&#x27;, &#x27;perturbation&#x27;, &#x27;replicate&#x27;, &#x27;S.Score&#x27;, &#x27;G2M.Score&#x27;, &#x27;Phase&#x27;\n",
-       "      var:\t&#x27;name&#x27;</pre>"
-      ],
-      "text/plain": [
-       "MuData object with n_obs × n_vars = 20729 × 18776\n",
-       "  4 modalities\n",
-       "    rna:\t20729 x 18649\n",
-       "      obs:\t'orig.ident', 'nCount_RNA', 'nFeature_RNA', 'nCount_HTO', 'nFeature_HTO', 'nCount_GDO', 'nCount_ADT', 'nFeature_ADT', 'percent.mito', 'MULTI_ID', 'HTO_classification', 'guide_ID', 'gene_target', 'perturbation', 'replicate', 'S.Score', 'G2M.Score', 'Phase'\n",
-       "      var:\t'name'\n",
-       "    adt:\t20729 x 4\n",
-       "      obs:\t'orig.ident', 'nCount_RNA', 'nFeature_RNA', 'nCount_HTO', 'nFeature_HTO', 'nCount_GDO', 'nCount_ADT', 'nFeature_ADT', 'percent.mito', 'MULTI_ID', 'HTO_classification', 'guide_ID', 'gene_target', 'perturbation', 'replicate', 'S.Score', 'G2M.Score', 'Phase'\n",
-       "      var:\t'name'\n",
-       "    hto:\t20729 x 12\n",
-       "      obs:\t'orig.ident', 'nCount_RNA', 'nFeature_RNA', 'nCount_HTO', 'nFeature_HTO', 'nCount_GDO', 'nCount_ADT', 'nFeature_ADT', 'percent.mito', 'MULTI_ID', 'HTO_classification', 'guide_ID', 'gene_target', 'perturbation', 'replicate', 'S.Score', 'G2M.Score', 'Phase'\n",
-       "      var:\t'name'\n",
-       "    gdo:\t20729 x 111\n",
-       "      obs:\t'orig.ident', 'nCount_RNA', 'nFeature_RNA', 'nCount_HTO', 'nFeature_HTO', 'nCount_GDO', 'nCount_ADT', 'nFeature_ADT', 'percent.mito', 'MULTI_ID', 'HTO_classification', 'guide_ID', 'gene_target', 'perturbation', 'replicate', 'S.Score', 'G2M.Score', 'Phase'\n",
-       "      var:\t'name'"
-      ]
-     },
-     "execution_count": 119,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# create mu data object\n",
     "mueasy = MuData({'rna': rna, 'adt': adt, 'hto':hto, 'gdo':gdo})\n",
@@ -110,121 +68,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 120,
+   "execution_count": null,
    "id": "324ab088",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/opt/miniconda3/envs/pertpy/lib/python3.8/site-packages/anndata/_core/anndata.py:1228: FutureWarning: The `inplace` parameter in pandas.Categorical.reorder_categories is deprecated and will be removed in a future version. Reordering categories will always return a new Categorical object.\n",
-      "  c.reorder_categories(natsorted(c.categories), inplace=True)\n",
-      "... storing 'orig.ident' as categorical\n",
-      "/opt/miniconda3/envs/pertpy/lib/python3.8/site-packages/anndata/_core/anndata.py:1228: FutureWarning: The `inplace` parameter in pandas.Categorical.reorder_categories is deprecated and will be removed in a future version. Reordering categories will always return a new Categorical object.\n",
-      "  c.reorder_categories(natsorted(c.categories), inplace=True)\n",
-      "... storing 'MULTI_ID' as categorical\n",
-      "/opt/miniconda3/envs/pertpy/lib/python3.8/site-packages/anndata/_core/anndata.py:1228: FutureWarning: The `inplace` parameter in pandas.Categorical.reorder_categories is deprecated and will be removed in a future version. Reordering categories will always return a new Categorical object.\n",
-      "  c.reorder_categories(natsorted(c.categories), inplace=True)\n",
-      "... storing 'HTO_classification' as categorical\n",
-      "/opt/miniconda3/envs/pertpy/lib/python3.8/site-packages/anndata/_core/anndata.py:1228: FutureWarning: The `inplace` parameter in pandas.Categorical.reorder_categories is deprecated and will be removed in a future version. Reordering categories will always return a new Categorical object.\n",
-      "  c.reorder_categories(natsorted(c.categories), inplace=True)\n",
-      "... storing 'guide_ID' as categorical\n",
-      "/opt/miniconda3/envs/pertpy/lib/python3.8/site-packages/anndata/_core/anndata.py:1228: FutureWarning: The `inplace` parameter in pandas.Categorical.reorder_categories is deprecated and will be removed in a future version. Reordering categories will always return a new Categorical object.\n",
-      "  c.reorder_categories(natsorted(c.categories), inplace=True)\n",
-      "... storing 'gene_target' as categorical\n",
-      "/opt/miniconda3/envs/pertpy/lib/python3.8/site-packages/anndata/_core/anndata.py:1228: FutureWarning: The `inplace` parameter in pandas.Categorical.reorder_categories is deprecated and will be removed in a future version. Reordering categories will always return a new Categorical object.\n",
-      "  c.reorder_categories(natsorted(c.categories), inplace=True)\n",
-      "... storing 'perturbation' as categorical\n",
-      "/opt/miniconda3/envs/pertpy/lib/python3.8/site-packages/anndata/_core/anndata.py:1228: FutureWarning: The `inplace` parameter in pandas.Categorical.reorder_categories is deprecated and will be removed in a future version. Reordering categories will always return a new Categorical object.\n",
-      "  c.reorder_categories(natsorted(c.categories), inplace=True)\n",
-      "... storing 'replicate' as categorical\n",
-      "/opt/miniconda3/envs/pertpy/lib/python3.8/site-packages/anndata/_core/anndata.py:1228: FutureWarning: The `inplace` parameter in pandas.Categorical.reorder_categories is deprecated and will be removed in a future version. Reordering categories will always return a new Categorical object.\n",
-      "  c.reorder_categories(natsorted(c.categories), inplace=True)\n",
-      "... storing 'Phase' as categorical\n",
-      "/opt/miniconda3/envs/pertpy/lib/python3.8/site-packages/anndata/_core/anndata.py:1228: FutureWarning: The `inplace` parameter in pandas.Categorical.reorder_categories is deprecated and will be removed in a future version. Reordering categories will always return a new Categorical object.\n",
-      "  c.reorder_categories(natsorted(c.categories), inplace=True)\n",
-      "... storing 'orig.ident' as categorical\n",
-      "/opt/miniconda3/envs/pertpy/lib/python3.8/site-packages/anndata/_core/anndata.py:1228: FutureWarning: The `inplace` parameter in pandas.Categorical.reorder_categories is deprecated and will be removed in a future version. Reordering categories will always return a new Categorical object.\n",
-      "  c.reorder_categories(natsorted(c.categories), inplace=True)\n",
-      "... storing 'MULTI_ID' as categorical\n",
-      "/opt/miniconda3/envs/pertpy/lib/python3.8/site-packages/anndata/_core/anndata.py:1228: FutureWarning: The `inplace` parameter in pandas.Categorical.reorder_categories is deprecated and will be removed in a future version. Reordering categories will always return a new Categorical object.\n",
-      "  c.reorder_categories(natsorted(c.categories), inplace=True)\n",
-      "... storing 'HTO_classification' as categorical\n",
-      "/opt/miniconda3/envs/pertpy/lib/python3.8/site-packages/anndata/_core/anndata.py:1228: FutureWarning: The `inplace` parameter in pandas.Categorical.reorder_categories is deprecated and will be removed in a future version. Reordering categories will always return a new Categorical object.\n",
-      "  c.reorder_categories(natsorted(c.categories), inplace=True)\n",
-      "... storing 'guide_ID' as categorical\n",
-      "/opt/miniconda3/envs/pertpy/lib/python3.8/site-packages/anndata/_core/anndata.py:1228: FutureWarning: The `inplace` parameter in pandas.Categorical.reorder_categories is deprecated and will be removed in a future version. Reordering categories will always return a new Categorical object.\n",
-      "  c.reorder_categories(natsorted(c.categories), inplace=True)\n",
-      "... storing 'gene_target' as categorical\n",
-      "/opt/miniconda3/envs/pertpy/lib/python3.8/site-packages/anndata/_core/anndata.py:1228: FutureWarning: The `inplace` parameter in pandas.Categorical.reorder_categories is deprecated and will be removed in a future version. Reordering categories will always return a new Categorical object.\n",
-      "  c.reorder_categories(natsorted(c.categories), inplace=True)\n",
-      "... storing 'perturbation' as categorical\n",
-      "/opt/miniconda3/envs/pertpy/lib/python3.8/site-packages/anndata/_core/anndata.py:1228: FutureWarning: The `inplace` parameter in pandas.Categorical.reorder_categories is deprecated and will be removed in a future version. Reordering categories will always return a new Categorical object.\n",
-      "  c.reorder_categories(natsorted(c.categories), inplace=True)\n",
-      "... storing 'replicate' as categorical\n",
-      "/opt/miniconda3/envs/pertpy/lib/python3.8/site-packages/anndata/_core/anndata.py:1228: FutureWarning: The `inplace` parameter in pandas.Categorical.reorder_categories is deprecated and will be removed in a future version. Reordering categories will always return a new Categorical object.\n",
-      "  c.reorder_categories(natsorted(c.categories), inplace=True)\n",
-      "... storing 'Phase' as categorical\n",
-      "/opt/miniconda3/envs/pertpy/lib/python3.8/site-packages/anndata/_core/anndata.py:1228: FutureWarning: The `inplace` parameter in pandas.Categorical.reorder_categories is deprecated and will be removed in a future version. Reordering categories will always return a new Categorical object.\n",
-      "  c.reorder_categories(natsorted(c.categories), inplace=True)\n",
-      "... storing 'orig.ident' as categorical\n",
-      "/opt/miniconda3/envs/pertpy/lib/python3.8/site-packages/anndata/_core/anndata.py:1228: FutureWarning: The `inplace` parameter in pandas.Categorical.reorder_categories is deprecated and will be removed in a future version. Reordering categories will always return a new Categorical object.\n",
-      "  c.reorder_categories(natsorted(c.categories), inplace=True)\n",
-      "... storing 'MULTI_ID' as categorical\n",
-      "/opt/miniconda3/envs/pertpy/lib/python3.8/site-packages/anndata/_core/anndata.py:1228: FutureWarning: The `inplace` parameter in pandas.Categorical.reorder_categories is deprecated and will be removed in a future version. Reordering categories will always return a new Categorical object.\n",
-      "  c.reorder_categories(natsorted(c.categories), inplace=True)\n",
-      "... storing 'HTO_classification' as categorical\n",
-      "/opt/miniconda3/envs/pertpy/lib/python3.8/site-packages/anndata/_core/anndata.py:1228: FutureWarning: The `inplace` parameter in pandas.Categorical.reorder_categories is deprecated and will be removed in a future version. Reordering categories will always return a new Categorical object.\n",
-      "  c.reorder_categories(natsorted(c.categories), inplace=True)\n",
-      "... storing 'guide_ID' as categorical\n",
-      "/opt/miniconda3/envs/pertpy/lib/python3.8/site-packages/anndata/_core/anndata.py:1228: FutureWarning: The `inplace` parameter in pandas.Categorical.reorder_categories is deprecated and will be removed in a future version. Reordering categories will always return a new Categorical object.\n",
-      "  c.reorder_categories(natsorted(c.categories), inplace=True)\n",
-      "... storing 'gene_target' as categorical\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/opt/miniconda3/envs/pertpy/lib/python3.8/site-packages/anndata/_core/anndata.py:1228: FutureWarning: The `inplace` parameter in pandas.Categorical.reorder_categories is deprecated and will be removed in a future version. Reordering categories will always return a new Categorical object.\n",
-      "  c.reorder_categories(natsorted(c.categories), inplace=True)\n",
-      "... storing 'perturbation' as categorical\n",
-      "/opt/miniconda3/envs/pertpy/lib/python3.8/site-packages/anndata/_core/anndata.py:1228: FutureWarning: The `inplace` parameter in pandas.Categorical.reorder_categories is deprecated and will be removed in a future version. Reordering categories will always return a new Categorical object.\n",
-      "  c.reorder_categories(natsorted(c.categories), inplace=True)\n",
-      "... storing 'replicate' as categorical\n",
-      "/opt/miniconda3/envs/pertpy/lib/python3.8/site-packages/anndata/_core/anndata.py:1228: FutureWarning: The `inplace` parameter in pandas.Categorical.reorder_categories is deprecated and will be removed in a future version. Reordering categories will always return a new Categorical object.\n",
-      "  c.reorder_categories(natsorted(c.categories), inplace=True)\n",
-      "... storing 'Phase' as categorical\n",
-      "/opt/miniconda3/envs/pertpy/lib/python3.8/site-packages/anndata/_core/anndata.py:1228: FutureWarning: The `inplace` parameter in pandas.Categorical.reorder_categories is deprecated and will be removed in a future version. Reordering categories will always return a new Categorical object.\n",
-      "  c.reorder_categories(natsorted(c.categories), inplace=True)\n",
-      "... storing 'orig.ident' as categorical\n",
-      "/opt/miniconda3/envs/pertpy/lib/python3.8/site-packages/anndata/_core/anndata.py:1228: FutureWarning: The `inplace` parameter in pandas.Categorical.reorder_categories is deprecated and will be removed in a future version. Reordering categories will always return a new Categorical object.\n",
-      "  c.reorder_categories(natsorted(c.categories), inplace=True)\n",
-      "... storing 'MULTI_ID' as categorical\n",
-      "/opt/miniconda3/envs/pertpy/lib/python3.8/site-packages/anndata/_core/anndata.py:1228: FutureWarning: The `inplace` parameter in pandas.Categorical.reorder_categories is deprecated and will be removed in a future version. Reordering categories will always return a new Categorical object.\n",
-      "  c.reorder_categories(natsorted(c.categories), inplace=True)\n",
-      "... storing 'HTO_classification' as categorical\n",
-      "/opt/miniconda3/envs/pertpy/lib/python3.8/site-packages/anndata/_core/anndata.py:1228: FutureWarning: The `inplace` parameter in pandas.Categorical.reorder_categories is deprecated and will be removed in a future version. Reordering categories will always return a new Categorical object.\n",
-      "  c.reorder_categories(natsorted(c.categories), inplace=True)\n",
-      "... storing 'guide_ID' as categorical\n",
-      "/opt/miniconda3/envs/pertpy/lib/python3.8/site-packages/anndata/_core/anndata.py:1228: FutureWarning: The `inplace` parameter in pandas.Categorical.reorder_categories is deprecated and will be removed in a future version. Reordering categories will always return a new Categorical object.\n",
-      "  c.reorder_categories(natsorted(c.categories), inplace=True)\n",
-      "... storing 'gene_target' as categorical\n",
-      "/opt/miniconda3/envs/pertpy/lib/python3.8/site-packages/anndata/_core/anndata.py:1228: FutureWarning: The `inplace` parameter in pandas.Categorical.reorder_categories is deprecated and will be removed in a future version. Reordering categories will always return a new Categorical object.\n",
-      "  c.reorder_categories(natsorted(c.categories), inplace=True)\n",
-      "... storing 'perturbation' as categorical\n",
-      "/opt/miniconda3/envs/pertpy/lib/python3.8/site-packages/anndata/_core/anndata.py:1228: FutureWarning: The `inplace` parameter in pandas.Categorical.reorder_categories is deprecated and will be removed in a future version. Reordering categories will always return a new Categorical object.\n",
-      "  c.reorder_categories(natsorted(c.categories), inplace=True)\n",
-      "... storing 'replicate' as categorical\n",
-      "/opt/miniconda3/envs/pertpy/lib/python3.8/site-packages/anndata/_core/anndata.py:1228: FutureWarning: The `inplace` parameter in pandas.Categorical.reorder_categories is deprecated and will be removed in a future version. Reordering categories will always return a new Categorical object.\n",
-      "  c.reorder_categories(natsorted(c.categories), inplace=True)\n",
-      "... storing 'Phase' as categorical\n",
-      "/opt/miniconda3/envs/pertpy/lib/python3.8/site-packages/mudata/_core/mudata.py:376: UserWarning: Cannot join columns with the same name because var_names are intersecting.\n",
-      "  warnings.warn(\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# save mu data \n",
     "mueasy.write('eccite.h5mu')"
@@ -232,8 +79,11 @@
   }
  ],
  "metadata": {
+  "interpreter": {
+   "hash": "2eba13af0803eb9e860329ab8d1c7035695cf806e36c019cf6c45960f8a9dcf9"
+  },
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3.9.12 ('.venv': poetry)",
    "language": "python",
    "name": "python3"
   },
@@ -247,7 +97,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.12"
+   "version": "3.9.12"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
```
# remove duplicate columns
ann.obs = ann.obs.T.drop_duplicates().T
```
The above code transposed dataframe twice, and it will change all data type to object. And finally this will lead to TypeError when writing mu data to h5mu file. 

Reverting original data types will solve this issue:
```
# save original data types
all_column_names = ann.obs_keys()
all_column_types = ann.obs.dtypes.to_dict()

# remove duplicate columns
ann.obs = ann.obs.T.drop_duplicates().T

all_column_names_new = ann.obs_keys()
    for duplicate_column_name in list(set(all_column_names) - set(all_column_names_new)):
        all_column_types.pop(duplicate_column_name)
# revert columns' data types
ann.obs = ann.obs.astype(all_column_types)
```