### PR TITLE
Added sciplex gxe 2 dataset scripts

### DIFF
--- a/McFaline-Figueroa et al. Multiplex single-cell chemical genomics reveals the kinase dependence of the response to targeted therapy/README.md
+++ b/McFaline-Figueroa et al. Multiplex single-cell chemical genomics reveals the kinase dependence of the response to targeted therapy/README.md
@@ -1,0 +1,6 @@
+
+The link to download the dataset can be found here: https://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc=GSM7056149
+
+The downloaded directory contains a single RDS file that has to be loaded into your R environment. The RDS file contains a list of Seurat objects, each corresponding to a different cell line.
+
+Then the Seurat objects are converted to a h5ad files and concatenated into a single h5ad file, which will be around 35GB if not compressed.

--- a/McFaline-Figueroa et al. Multiplex single-cell chemical genomics reveals the kinase dependence of the response to targeted therapy/sciPlexGxE_concatenation.ipynb
+++ b/McFaline-Figueroa et al. Multiplex single-cell chemical genomics reveals the kinase dependence of the response to targeted therapy/sciPlexGxE_concatenation.ipynb
@@ -1,0 +1,800 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "0f513212-ad5c-424f-85b7-469418aa7799",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #808000; text-decoration-color: #808000; font-weight: bold\">ryp2 is not installed. Install with </span><span style=\"color: #008000; text-decoration-color: #008000; font-weight: bold\">pip install rpy2 </span><span style=\"color: #808000; text-decoration-color: #808000; font-weight: bold\">to run tools with R support.</span>\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "\u001b[1;33mryp2 is not installed. Install with \u001b[0m\u001b[1;32mpip install rpy2 \u001b[0m\u001b[1;33mto run tools with R support.\u001b[0m\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "import anndata as ad\n",
+    "import scanpy as sc"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "b14f9bc8-7a13-490f-892e-df7aacb4584e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "adata_A172 = sc.read_h5ad(\"cds_A172.h5ad\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "8e3dca73-41b4-428b-b674-ce684a7e1763",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "adata_T98G = sc.read_h5ad(\"cds_T98G.h5ad\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "05df05be-ae0f-401a-aee0-752fc7d0b9d8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "adata_U87MG = sc.read_h5ad(\"cds_U87MG.h5ad\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "id": "d3fed111-1578-485a-b66d-488d9a51d7b4",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "AnnData object with n_obs × n_vars = 335088 × 58347\n",
+       "    obs: 'orig.ident', 'nCount_originalexp', 'nFeature_originalexp', 'cell', 'sample', 'Size_Factor', 'n.umi', 'hash_umis', 'pval', 'qval', 'top_to_second_best_ratio', 'top_oligo', 'RT_well', 'Lig_well', 'P7_index', 'P5_index', 'PCR_plate', 'P5_cell', 'new_cell', 'scrublet_score', 'background_loading', 'hash_plate', 'cell_line', 'treatment', 'dose', 'replicate', 'gRNA_id', 'gene_id', 'guide_number', 'gRNA_maxCount', 'gRNA_topRatio'\n",
+       "    var: 'id', 'gene_short_name'"
+      ]
+     },
+     "execution_count": 26,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "adata_A172"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "id": "edc117fe-e421-40f0-80e5-a55f7dbab879",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "AnnData object with n_obs × n_vars = 325455 × 58347\n",
+       "    obs: 'orig.ident', 'nCount_originalexp', 'nFeature_originalexp', 'cell', 'sample', 'Size_Factor', 'n.umi', 'hash_umis', 'pval', 'qval', 'top_to_second_best_ratio', 'top_oligo', 'RT_well', 'Lig_well', 'P7_index', 'P5_index', 'PCR_plate', 'P5_cell', 'new_cell', 'scrublet_score', 'background_loading', 'hash_plate', 'cell_line', 'treatment', 'dose', 'replicate', 'gRNA_id', 'gene_id', 'guide_number', 'gRNA_maxCount', 'gRNA_topRatio'\n",
+       "    var: 'id', 'gene_short_name'"
+      ]
+     },
+     "execution_count": 27,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "adata_T98G"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "id": "4b11a76a-8589-48bf-8eb8-802b9a9bf265",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "AnnData object with n_obs × n_vars = 328756 × 58347\n",
+       "    obs: 'orig.ident', 'nCount_originalexp', 'nFeature_originalexp', 'cell', 'sample', 'Size_Factor', 'n.umi', 'hash_umis', 'pval', 'qval', 'top_to_second_best_ratio', 'top_oligo', 'RT_well', 'Lig_well', 'P7_index', 'P5_index', 'PCR_plate', 'P5_cell', 'new_cell', 'scrublet_score', 'background_loading', 'hash_plate', 'cell_line', 'treatment', 'dose', 'replicate', 'gRNA_id', 'gene_id', 'guide_number', 'gRNA_maxCount', 'gRNA_topRatio'\n",
+       "    var: 'id', 'gene_short_name'"
+      ]
+     },
+     "execution_count": 28,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "adata_U87MG"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "id": "eeee084c-1504-421a-8ea3-3990d81eef26",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "big_adata = ad.concat([adata_A172, adata_T98G, adata_U87MG], join=\"outer\", merge=\"same\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "id": "f1e7cc29-bcca-46a2-bbc7-0ee01e33c680",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "AnnData object with n_obs × n_vars = 989299 × 58347\n",
+       "    obs: 'orig.ident', 'nCount_originalexp', 'nFeature_originalexp', 'cell', 'sample', 'Size_Factor', 'n.umi', 'hash_umis', 'pval', 'qval', 'top_to_second_best_ratio', 'top_oligo', 'RT_well', 'Lig_well', 'P7_index', 'P5_index', 'PCR_plate', 'P5_cell', 'new_cell', 'scrublet_score', 'background_loading', 'hash_plate', 'cell_line', 'treatment', 'dose', 'replicate', 'gRNA_id', 'gene_id', 'guide_number', 'gRNA_maxCount', 'gRNA_topRatio'\n",
+       "    var: 'id', 'gene_short_name'"
+      ]
+     },
+     "execution_count": 23,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "big_adata"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "id": "8f198afa-5e01-45d2-8d1f-ddae49a74190",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>orig.ident</th>\n",
+       "      <th>nCount_originalexp</th>\n",
+       "      <th>nFeature_originalexp</th>\n",
+       "      <th>cell</th>\n",
+       "      <th>sample</th>\n",
+       "      <th>Size_Factor</th>\n",
+       "      <th>n.umi</th>\n",
+       "      <th>hash_umis</th>\n",
+       "      <th>pval</th>\n",
+       "      <th>qval</th>\n",
+       "      <th>...</th>\n",
+       "      <th>hash_plate</th>\n",
+       "      <th>cell_line</th>\n",
+       "      <th>treatment</th>\n",
+       "      <th>dose</th>\n",
+       "      <th>replicate</th>\n",
+       "      <th>gRNA_id</th>\n",
+       "      <th>gene_id</th>\n",
+       "      <th>guide_number</th>\n",
+       "      <th>gRNA_maxCount</th>\n",
+       "      <th>gRNA_topRatio</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>01A_A01_RT_BC_100_Lig_BC_134</th>\n",
+       "      <td>0</td>\n",
+       "      <td>2689.0</td>\n",
+       "      <td>1533</td>\n",
+       "      <td>01A_A01_RT_BC_100_Lig_BC_134</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1.064809</td>\n",
+       "      <td>2689.0</td>\n",
+       "      <td>220.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>...</td>\n",
+       "      <td>11</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>PHKG2_4</td>\n",
+       "      <td>PHKG2</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>502</td>\n",
+       "      <td>0.896429</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>01A_A01_RT_BC_100_Lig_BC_253</th>\n",
+       "      <td>0</td>\n",
+       "      <td>3367.0</td>\n",
+       "      <td>1803</td>\n",
+       "      <td>01A_A01_RT_BC_100_Lig_BC_253</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1.333288</td>\n",
+       "      <td>3367.0</td>\n",
+       "      <td>253.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>...</td>\n",
+       "      <td>9</td>\n",
+       "      <td>0</td>\n",
+       "      <td>4</td>\n",
+       "      <td>10</td>\n",
+       "      <td>0</td>\n",
+       "      <td>DAPK1_2</td>\n",
+       "      <td>DAPK1</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>467</td>\n",
+       "      <td>0.917485</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>01A_A01_RT_BC_100_Lig_BC_26</th>\n",
+       "      <td>0</td>\n",
+       "      <td>3724.0</td>\n",
+       "      <td>2306</td>\n",
+       "      <td>01A_A01_RT_BC_100_Lig_BC_26</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1.474655</td>\n",
+       "      <td>3724.0</td>\n",
+       "      <td>236.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>...</td>\n",
+       "      <td>9</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>10</td>\n",
+       "      <td>0</td>\n",
+       "      <td>MYO3B_3</td>\n",
+       "      <td>MYO3B</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>784</td>\n",
+       "      <td>0.894977</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>01A_A01_RT_BC_100_Lig_BC_340</th>\n",
+       "      <td>0</td>\n",
+       "      <td>2547.0</td>\n",
+       "      <td>1529</td>\n",
+       "      <td>01A_A01_RT_BC_100_Lig_BC_340</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1.008579</td>\n",
+       "      <td>2547.0</td>\n",
+       "      <td>267.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>...</td>\n",
+       "      <td>8</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>10</td>\n",
+       "      <td>0</td>\n",
+       "      <td>CDK9_3</td>\n",
+       "      <td>CDK9</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>275</td>\n",
+       "      <td>0.867508</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>01A_A01_RT_BC_100_Lig_BC_83</th>\n",
+       "      <td>0</td>\n",
+       "      <td>3255.0</td>\n",
+       "      <td>1786</td>\n",
+       "      <td>01A_A01_RT_BC_100_Lig_BC_83</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1.288937</td>\n",
+       "      <td>3255.0</td>\n",
+       "      <td>865.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>...</td>\n",
+       "      <td>11</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>10</td>\n",
+       "      <td>0</td>\n",
+       "      <td>NEK9_2</td>\n",
+       "      <td>NEK9</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>482</td>\n",
+       "      <td>0.894249</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>...</th>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>12D_H12_RT_BC_99_Lig_BC_147</th>\n",
+       "      <td>47</td>\n",
+       "      <td>1648.0</td>\n",
+       "      <td>1027</td>\n",
+       "      <td>12D_H12_RT_BC_99_Lig_BC_147</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0.652586</td>\n",
+       "      <td>1648.0</td>\n",
+       "      <td>185.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>...</td>\n",
+       "      <td>14</td>\n",
+       "      <td>2</td>\n",
+       "      <td>1</td>\n",
+       "      <td>10</td>\n",
+       "      <td>0</td>\n",
+       "      <td>PTK6_1</td>\n",
+       "      <td>PTK6</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>2766</td>\n",
+       "      <td>0.928811</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>12D_H12_RT_BC_99_Lig_BC_303</th>\n",
+       "      <td>47</td>\n",
+       "      <td>1728.0</td>\n",
+       "      <td>1025</td>\n",
+       "      <td>12D_H12_RT_BC_99_Lig_BC_303</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0.684265</td>\n",
+       "      <td>1728.0</td>\n",
+       "      <td>270.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>...</td>\n",
+       "      <td>17</td>\n",
+       "      <td>2</td>\n",
+       "      <td>0</td>\n",
+       "      <td>10</td>\n",
+       "      <td>0</td>\n",
+       "      <td>ARAF_4</td>\n",
+       "      <td>ARAF</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>822</td>\n",
+       "      <td>0.916388</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>12D_H12_RT_BC_99_Lig_BC_307</th>\n",
+       "      <td>47</td>\n",
+       "      <td>868.0</td>\n",
+       "      <td>591</td>\n",
+       "      <td>12D_H12_RT_BC_99_Lig_BC_307</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0.343717</td>\n",
+       "      <td>868.0</td>\n",
+       "      <td>65.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>...</td>\n",
+       "      <td>14</td>\n",
+       "      <td>2</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>ERN2_3</td>\n",
+       "      <td>ERN2</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1.000000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>12D_H12_RT_BC_99_Lig_BC_34</th>\n",
+       "      <td>47</td>\n",
+       "      <td>2675.0</td>\n",
+       "      <td>1420</td>\n",
+       "      <td>12D_H12_RT_BC_99_Lig_BC_34</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1.059265</td>\n",
+       "      <td>2675.0</td>\n",
+       "      <td>314.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>...</td>\n",
+       "      <td>15</td>\n",
+       "      <td>2</td>\n",
+       "      <td>1</td>\n",
+       "      <td>10</td>\n",
+       "      <td>0</td>\n",
+       "      <td>CDK9_2</td>\n",
+       "      <td>CDK9</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>388</td>\n",
+       "      <td>0.919431</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>12D_H12_RT_BC_9_Lig_BC_174</th>\n",
+       "      <td>47</td>\n",
+       "      <td>1142.0</td>\n",
+       "      <td>875</td>\n",
+       "      <td>12D_H12_RT_BC_9_Lig_BC_174</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0.452217</td>\n",
+       "      <td>1142.0</td>\n",
+       "      <td>213.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>...</td>\n",
+       "      <td>14</td>\n",
+       "      <td>2</td>\n",
+       "      <td>0</td>\n",
+       "      <td>10</td>\n",
+       "      <td>0</td>\n",
+       "      <td>BRAF_2</td>\n",
+       "      <td>BRAF</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>470</td>\n",
+       "      <td>0.925197</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>989299 rows × 31 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                              orig.ident  nCount_originalexp  \\\n",
+       "01A_A01_RT_BC_100_Lig_BC_134           0              2689.0   \n",
+       "01A_A01_RT_BC_100_Lig_BC_253           0              3367.0   \n",
+       "01A_A01_RT_BC_100_Lig_BC_26            0              3724.0   \n",
+       "01A_A01_RT_BC_100_Lig_BC_340           0              2547.0   \n",
+       "01A_A01_RT_BC_100_Lig_BC_83            0              3255.0   \n",
+       "...                                  ...                 ...   \n",
+       "12D_H12_RT_BC_99_Lig_BC_147           47              1648.0   \n",
+       "12D_H12_RT_BC_99_Lig_BC_303           47              1728.0   \n",
+       "12D_H12_RT_BC_99_Lig_BC_307           47               868.0   \n",
+       "12D_H12_RT_BC_99_Lig_BC_34            47              2675.0   \n",
+       "12D_H12_RT_BC_9_Lig_BC_174            47              1142.0   \n",
+       "\n",
+       "                              nFeature_originalexp  \\\n",
+       "01A_A01_RT_BC_100_Lig_BC_134                  1533   \n",
+       "01A_A01_RT_BC_100_Lig_BC_253                  1803   \n",
+       "01A_A01_RT_BC_100_Lig_BC_26                   2306   \n",
+       "01A_A01_RT_BC_100_Lig_BC_340                  1529   \n",
+       "01A_A01_RT_BC_100_Lig_BC_83                   1786   \n",
+       "...                                            ...   \n",
+       "12D_H12_RT_BC_99_Lig_BC_147                   1027   \n",
+       "12D_H12_RT_BC_99_Lig_BC_303                   1025   \n",
+       "12D_H12_RT_BC_99_Lig_BC_307                    591   \n",
+       "12D_H12_RT_BC_99_Lig_BC_34                    1420   \n",
+       "12D_H12_RT_BC_9_Lig_BC_174                     875   \n",
+       "\n",
+       "                                                      cell  sample  \\\n",
+       "01A_A01_RT_BC_100_Lig_BC_134  01A_A01_RT_BC_100_Lig_BC_134       0   \n",
+       "01A_A01_RT_BC_100_Lig_BC_253  01A_A01_RT_BC_100_Lig_BC_253       0   \n",
+       "01A_A01_RT_BC_100_Lig_BC_26    01A_A01_RT_BC_100_Lig_BC_26       0   \n",
+       "01A_A01_RT_BC_100_Lig_BC_340  01A_A01_RT_BC_100_Lig_BC_340       0   \n",
+       "01A_A01_RT_BC_100_Lig_BC_83    01A_A01_RT_BC_100_Lig_BC_83       0   \n",
+       "...                                                    ...     ...   \n",
+       "12D_H12_RT_BC_99_Lig_BC_147    12D_H12_RT_BC_99_Lig_BC_147       0   \n",
+       "12D_H12_RT_BC_99_Lig_BC_303    12D_H12_RT_BC_99_Lig_BC_303       0   \n",
+       "12D_H12_RT_BC_99_Lig_BC_307    12D_H12_RT_BC_99_Lig_BC_307       0   \n",
+       "12D_H12_RT_BC_99_Lig_BC_34      12D_H12_RT_BC_99_Lig_BC_34       0   \n",
+       "12D_H12_RT_BC_9_Lig_BC_174      12D_H12_RT_BC_9_Lig_BC_174       0   \n",
+       "\n",
+       "                              Size_Factor   n.umi  hash_umis  pval  qval  ...  \\\n",
+       "01A_A01_RT_BC_100_Lig_BC_134     1.064809  2689.0      220.0   0.0   0.0  ...   \n",
+       "01A_A01_RT_BC_100_Lig_BC_253     1.333288  3367.0      253.0   0.0   0.0  ...   \n",
+       "01A_A01_RT_BC_100_Lig_BC_26      1.474655  3724.0      236.0   0.0   0.0  ...   \n",
+       "01A_A01_RT_BC_100_Lig_BC_340     1.008579  2547.0      267.0   0.0   0.0  ...   \n",
+       "01A_A01_RT_BC_100_Lig_BC_83      1.288937  3255.0      865.0   0.0   0.0  ...   \n",
+       "...                                   ...     ...        ...   ...   ...  ...   \n",
+       "12D_H12_RT_BC_99_Lig_BC_147      0.652586  1648.0      185.0   0.0   0.0  ...   \n",
+       "12D_H12_RT_BC_99_Lig_BC_303      0.684265  1728.0      270.0   0.0   0.0  ...   \n",
+       "12D_H12_RT_BC_99_Lig_BC_307      0.343717   868.0       65.0   0.0   0.0  ...   \n",
+       "12D_H12_RT_BC_99_Lig_BC_34       1.059265  2675.0      314.0   0.0   0.0  ...   \n",
+       "12D_H12_RT_BC_9_Lig_BC_174       0.452217  1142.0      213.0   0.0   0.0  ...   \n",
+       "\n",
+       "                              hash_plate  cell_line  treatment  dose  \\\n",
+       "01A_A01_RT_BC_100_Lig_BC_134          11          0          1     1   \n",
+       "01A_A01_RT_BC_100_Lig_BC_253           9          0          4    10   \n",
+       "01A_A01_RT_BC_100_Lig_BC_26            9          0          0    10   \n",
+       "01A_A01_RT_BC_100_Lig_BC_340           8          0          0    10   \n",
+       "01A_A01_RT_BC_100_Lig_BC_83           11          0          0    10   \n",
+       "...                                  ...        ...        ...   ...   \n",
+       "12D_H12_RT_BC_99_Lig_BC_147           14          2          1    10   \n",
+       "12D_H12_RT_BC_99_Lig_BC_303           17          2          0    10   \n",
+       "12D_H12_RT_BC_99_Lig_BC_307           14          2          1     1   \n",
+       "12D_H12_RT_BC_99_Lig_BC_34            15          2          1    10   \n",
+       "12D_H12_RT_BC_9_Lig_BC_174            14          2          0    10   \n",
+       "\n",
+       "                             replicate  gRNA_id gene_id guide_number  \\\n",
+       "01A_A01_RT_BC_100_Lig_BC_134         0  PHKG2_4   PHKG2          1.0   \n",
+       "01A_A01_RT_BC_100_Lig_BC_253         0  DAPK1_2   DAPK1          1.0   \n",
+       "01A_A01_RT_BC_100_Lig_BC_26          0  MYO3B_3   MYO3B          1.0   \n",
+       "01A_A01_RT_BC_100_Lig_BC_340         0   CDK9_3    CDK9          1.0   \n",
+       "01A_A01_RT_BC_100_Lig_BC_83          0   NEK9_2    NEK9          1.0   \n",
+       "...                                ...      ...     ...          ...   \n",
+       "12D_H12_RT_BC_99_Lig_BC_147          0   PTK6_1    PTK6          1.0   \n",
+       "12D_H12_RT_BC_99_Lig_BC_303          0   ARAF_4    ARAF          1.0   \n",
+       "12D_H12_RT_BC_99_Lig_BC_307          0   ERN2_3    ERN2          1.0   \n",
+       "12D_H12_RT_BC_99_Lig_BC_34           0   CDK9_2    CDK9          1.0   \n",
+       "12D_H12_RT_BC_9_Lig_BC_174           0   BRAF_2    BRAF          1.0   \n",
+       "\n",
+       "                             gRNA_maxCount  gRNA_topRatio  \n",
+       "01A_A01_RT_BC_100_Lig_BC_134           502       0.896429  \n",
+       "01A_A01_RT_BC_100_Lig_BC_253           467       0.917485  \n",
+       "01A_A01_RT_BC_100_Lig_BC_26            784       0.894977  \n",
+       "01A_A01_RT_BC_100_Lig_BC_340           275       0.867508  \n",
+       "01A_A01_RT_BC_100_Lig_BC_83            482       0.894249  \n",
+       "...                                    ...            ...  \n",
+       "12D_H12_RT_BC_99_Lig_BC_147           2766       0.928811  \n",
+       "12D_H12_RT_BC_99_Lig_BC_303            822       0.916388  \n",
+       "12D_H12_RT_BC_99_Lig_BC_307              1       1.000000  \n",
+       "12D_H12_RT_BC_99_Lig_BC_34             388       0.919431  \n",
+       "12D_H12_RT_BC_9_Lig_BC_174             470       0.925197  \n",
+       "\n",
+       "[989299 rows x 31 columns]"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "big_adata.obs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "id": "c8f93ebc-cd9a-4d6f-8a29-89f6d1ba5ba6",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>id</th>\n",
+       "      <th>gene_short_name</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>ENSG00000000003.14</th>\n",
+       "      <td>ENSG00000000003.14</td>\n",
+       "      <td>TSPAN6</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>ENSG00000000005.5</th>\n",
+       "      <td>ENSG00000000005.5</td>\n",
+       "      <td>TNMD</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>ENSG00000000419.12</th>\n",
+       "      <td>ENSG00000000419.12</td>\n",
+       "      <td>DPM1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>ENSG00000000457.13</th>\n",
+       "      <td>ENSG00000000457.13</td>\n",
+       "      <td>SCYL3</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>ENSG00000000460.16</th>\n",
+       "      <td>ENSG00000000460.16</td>\n",
+       "      <td>C1orf112</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>...</th>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>ENSG00000284744.1</th>\n",
+       "      <td>ENSG00000284744.1</td>\n",
+       "      <td>AL591163.1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>ENSG00000284745.1</th>\n",
+       "      <td>ENSG00000284745.1</td>\n",
+       "      <td>AL589702.1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>ENSG00000284746.1</th>\n",
+       "      <td>ENSG00000284746.1</td>\n",
+       "      <td>AC068587.10</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>ENSG00000284747.1</th>\n",
+       "      <td>ENSG00000284747.1</td>\n",
+       "      <td>AL034417.4</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>ENSG00000284748.1</th>\n",
+       "      <td>ENSG00000284748.1</td>\n",
+       "      <td>AL513220.1</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>58347 rows × 2 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                                    id gene_short_name\n",
+       "ENSG00000000003.14  ENSG00000000003.14          TSPAN6\n",
+       "ENSG00000000005.5    ENSG00000000005.5            TNMD\n",
+       "ENSG00000000419.12  ENSG00000000419.12            DPM1\n",
+       "ENSG00000000457.13  ENSG00000000457.13           SCYL3\n",
+       "ENSG00000000460.16  ENSG00000000460.16        C1orf112\n",
+       "...                                ...             ...\n",
+       "ENSG00000284744.1    ENSG00000284744.1      AL591163.1\n",
+       "ENSG00000284745.1    ENSG00000284745.1      AL589702.1\n",
+       "ENSG00000284746.1    ENSG00000284746.1     AC068587.10\n",
+       "ENSG00000284747.1    ENSG00000284747.1      AL034417.4\n",
+       "ENSG00000284748.1    ENSG00000284748.1      AL513220.1\n",
+       "\n",
+       "[58347 rows x 2 columns]"
+      ]
+     },
+     "execution_count": 25,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "big_adata.var"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "id": "f52ad8e5-7c23-48e4-9ba8-aa28d7391d5d",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 30,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "adata_A172.var.equals(big_adata.var)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "id": "c9d564a1-579e-48e0-822c-1127656d833b",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 31,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "adata_A172.var.equals(adata_T98G.var)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "id": "963ed4a3-ff6d-40cc-a90b-a569a166d1ba",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 32,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "adata_A172.var.equals(adata_U87MG.var)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 35,
+   "id": "e2c8149e-3e09-4672-8add-77d01d68844f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "big_adata.write_h5ad(\n",
+    "    \"big_adata.h5ad.gzip\",\n",
+    "    compression=\"gzip\",\n",
+    ")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "pertpy",
+   "language": "python",
+   "name": "pertpy"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/McFaline-Figueroa et al. Multiplex single-cell chemical genomics reveals the kinase dependence of the response to targeted therapy/sciplex_convert_to_h5ad.R
+++ b/McFaline-Figueroa et al. Multiplex single-cell chemical genomics reveals the kinase dependence of the response to targeted therapy/sciplex_convert_to_h5ad.R
@@ -1,0 +1,17 @@
+library(Seurat)
+library(SeuratDisk)
+library(SeuratData)
+
+sciPlex_cds <- readRDS("GSM7056149_sciPlexGxE_2_preprocessed_cds.rds")
+
+cds_A172 <- as.Seurat(sciPlex_cds$A172, data = NULL)
+cds_T98G <- as.Seurat(sciPlex_cds$T98G, data = NULL)
+cds_U87MG <- as.Seurat(sciPlex_cds$U87MG, data = NULL)
+
+SaveH5Seurat(cds_A172, filename = "cds_A172.h5Seurat")
+SaveH5Seurat(cds_T98G, filename = "cds_T98G.h5Seurat")
+SaveH5Seurat(cds_U87MG, filename = "cds_U87MG.h5Seurat")
+
+Convert("cds_A172.h5Seurat", dest = "h5ad")
+Convert("cds_T98G.h5Seurat", dest = "h5ad")
+Convert("cds_U87MG.h5Seurat", dest = "h5ad")


### PR DESCRIPTION
The second dataset from https://www.cell.com/cell-genomics/fulltext/S2666-979X(23)00339-7 aka https://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc=GSM7056149 is too heavy to add as a dataloader to pertpy. Therefore, I added my scripts I used to convert and concatenate to h5ad. 

I still have the final h5ad, so ping me if you need it. 